### PR TITLE
fix: use correct types for `width`, `height` of thumbnail

### DIFF
--- a/parsers.go
+++ b/parsers.go
@@ -26,8 +26,8 @@ func ParseChannel(data interface{}) ChannelParser {
 				Name: data.(map[string]interface{})["title"].(map[string]interface{})["simpleText"].(string),
 				Icon: Thumbnail{
 					Url:    thumbnail.(map[string]interface{})["url"].(string),
-					Width:  thumbnail.(map[string]interface{})["width"].(string),
-					Height: thumbnail.(map[string]interface{})["height"].(string),
+					Width:  thumbnail.(map[string]interface{})["width"].(float64),
+					Height: thumbnail.(map[string]interface{})["height"].(float64),
 				},
 				Subscribers: data.(map[string]interface{})["subscriberCountText"].(map[string]interface{})["simpleText"].(string),
 			},
@@ -54,8 +54,8 @@ func ParseVideo(data interface{}) VideoParser {
 				Thumbnail: Thumbnail{
 					Id:     data.(map[string]interface{})["videoId"].(string),
 					Url:    thumbnail[len(thumbnail)-1].(map[string]interface{})["url"].(string),
-					Width:  fmt.Sprintf("%v", thumbnail[len(thumbnail)-1].(map[string]interface{})["width"]),
-					Height: fmt.Sprintf("%v", thumbnail[len(thumbnail)-1].(map[string]interface{})["height"]),
+					Width:  thumbnail[len(thumbnail)-1].(map[string]interface{})["width"].(float64),
+					Height: thumbnail[len(thumbnail)-1].(map[string]interface{})["height"].(float64),
 				},
 			},
 			IsSuccess: true,

--- a/types.go
+++ b/types.go
@@ -1,7 +1,8 @@
 package youtubego
 
 type Thumbnail struct {
-	Id, Width, Height, Url string
+	Id, Url       string
+	Width, Height float64
 }
 
 type Video struct {


### PR DESCRIPTION
fixes 
```
panic: interface conversion: interface {} is float64, not string

goroutine 82 [running]:
github.com/SherlockYigit/youtube-go.ParseChannel({0xf61e60?, 0xc0008c0420})
        /home/satont/Projects/tsuwari/.devbox/nix/profile/pkg/mod/github.com/!sherlock!yigit/youtube-go@v1.0.0/parsers.go:29 +0x47a
github.com/SherlockYigit/youtube-go.ParseHTML({0xc000e1a000, 0x90ef1}, 0x5)
        /home/satont/Projects/tsuwari/.devbox/nix/profile/pkg/mod/github.com/!sherlock!yigit/youtube-go@v1.0.0/util.go:90 +0x678
github.com/SherlockYigit/youtube-go.CreateRequest({0xc00080acd8, 0x6}, {0xc00085a6a0?, {0xc00080ace8?, 0x2?}})
        /home/satont/Projects/tsuwari/.devbox/nix/profile/pkg/mod/github.com/!sherlock!yigit/youtube-go@v1.0.0/util.go:49 +0x75a
```