### PR TITLE
fix: add `IsSuccess` field to output of parsing

### DIFF
--- a/parsers.go
+++ b/parsers.go
@@ -31,6 +31,7 @@ func ParseChannel(data interface{}) ChannelParser {
 				},
 				Subscribers: data.(map[string]interface{})["subscriberCountText"].(map[string]interface{})["simpleText"].(string),
 			},
+			IsSuccess: true,
 		}
 
 		return out


### PR DESCRIPTION
Without that field channel struct is empty.