### PR TITLE
refactor: do not panic if error happened

### DIFF
--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package youtubego
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -9,11 +10,11 @@ import (
 	"strings"
 )
 
-func CreateRequest(searchWord string, options SearchOptions) []SearchResult {
+func CreateRequest(searchWord string, options SearchOptions) ([]SearchResult, error) {
 	Url, err := url.Parse("http://youtube.com/results")
 
 	if err != nil {
-		panic("The URL is incorrect!")
+		return nil, errors.New("the URL is incorrect!")
 	}
 
 	query := url.Values{}
@@ -35,7 +36,7 @@ func CreateRequest(searchWord string, options SearchOptions) []SearchResult {
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		panic("Something went wrong, the request cannot be sent to the URL!")
+		return nil, errors.New("something went wrong, the request cannot be sent to the URL!")
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 200 {
@@ -49,7 +50,7 @@ func CreateRequest(searchWord string, options SearchOptions) []SearchResult {
 	return ParseHTML(string(bodyResp), options.Limit)
 }
 
-func ParseHTML(html string, limit int) []SearchResult {
+func ParseHTML(html string, limit int) ([]SearchResult, error) {
 	index := len(strings.Split(html, `{"itemSectionRenderer":`)) - 1
 	items := strings.Split(html, `{"itemSectionRenderer":`)[index]
 	parsed := strings.Split(items, `},{"continuationItemRenderer":{`)[0]
@@ -58,7 +59,7 @@ func ParseHTML(html string, limit int) []SearchResult {
 	err := json.Unmarshal([]byte(string(parsed)), &out)
 
 	if err != nil {
-		panic("Something went wrong, the problem was encountered while analyzing JSON!")
+		return nil, errors.New("something went wrong, the problem was encountered while analyzing JSON!")
 	}
 	arr := out["contents"].([]interface{})
 	output := []SearchResult{}
@@ -97,5 +98,5 @@ func ParseHTML(html string, limit int) []SearchResult {
 		}
 	}
 
-	return output
+	return output, nil
 }

--- a/youtube.go
+++ b/youtube.go
@@ -1,7 +1,7 @@
 package youtubego
 
-func Search(searchq string, options SearchOptions) []SearchResult {
-	res := CreateRequest(searchq, options)
+func Search(searchq string, options SearchOptions) ([]SearchResult, error) {
+	res, err := CreateRequest(searchq, options)
 
-	return res
+	return res, err
 }


### PR DESCRIPTION
This behavior it totally incorrect for golang libraries. Libraries should never throw panic.