### PR TITLE
fix: Fixed an issue where the video title was not readable.

### DIFF
--- a/internal/utils/parsing_helpers.go
+++ b/internal/utils/parsing_helpers.go
@@ -21,8 +21,8 @@ func ParsePlaylist(data interface{}) models.PlaylistParser {
 
 	// Parse the rest of the data
 	playlist := models.Playlist{
-		ID:       getStringValue(data, "playlistId"),
-		Title:    getStringValue(data, "title", "simpleText"),
+		ID:    getStringValue(data, "playlistId"),
+		Title: getStringValue(data, "title", "simpleText"),
 		Thumbnail: models.Thumbnail{
 			Url:    getStringValue(thumbnail, "url"),
 			Width:  getFloat64Value(thumbnail, "width"),
@@ -52,9 +52,9 @@ func ParseChannel(data interface{}) models.ChannelParser {
 
 	// Parse the rest of the data
 	channel := models.Channel{
-		ID:          getStringValue(data, "channelId"),
-		Name:        getStringValue(data, "title", "simpleText"),
-		Icon:        models.Thumbnail{
+		ID:   getStringValue(data, "channelId"),
+		Name: getStringValue(data, "title", "simpleText"),
+		Icon: models.Thumbnail{
 			Url:    getStringValue(thumbnail, "url"),
 			Width:  getFloat64Value(thumbnail, "width"),
 			Height: getFloat64Value(thumbnail, "height"),
@@ -85,7 +85,7 @@ func ParseVideo(data interface{}) models.VideoParser {
 	// Parse the rest of the data
 	video := models.Video{
 		ID:    getStringValue(data, "videoId"),
-		Title: getStringValue(data, "title", "runs", "0", "text"),
+		Title: getStringValue(getArrayValue(data, "title", "runs")[0], "text"),
 		Url:   fmt.Sprintf("https://www.youtube.com/watch?v=%s", getStringValue(data, "videoId")),
 		Thumbnail: models.Thumbnail{
 			ID:     getStringValue(data, "videoId"),


### PR DESCRIPTION
This pull request includes a small but significant change to the `ParseVideo` function in the `internal/utils/parsing_helpers.go` file. The change modifies how the `Title` field is extracted from the `data` object, ensuring that the correct text value is retrieved from the array.

* [`internal/utils/parsing_helpers.go`](diffhunk://#diff-3cbd880c029831dc57bf0ae03f0fdf458e2e97b59be27f7217c57194b93056f3L88-R88): Changed the `Title` field extraction in `ParseVideo` to use `getArrayValue` for accessing the first element of the `runs` array before retrieving the `text` value.