### PR TITLE
fix: return empty string for unsupported search types and update para…

### DIFF
--- a/internal/utils/search_type.go
+++ b/internal/utils/search_type.go
@@ -17,6 +17,6 @@ func GetSearchType(searchType string) string {
 	case "channel":
 		return SearchTypeChannelId
 	default:
-		return SearchTypeVideoId
+		return ""
 	}
 }

--- a/main.go
+++ b/main.go
@@ -14,9 +14,10 @@ import (
 func Search(query string, config models.SearchConfig) ([]models.SearchResult, error) {
 	searchType := utils.GetSearchType(config.SearchType)
 
-	params := map[string]string{
-		"search_query": query,
-		"sp":           searchType,
+	params := map[string]string{"search_query": query}
+
+	if searchType != "" {
+		params["sp"] = searchType
 	}
 
 	url, err := utils.BuildURLWithQueryParams("http://youtube.com/results", params)


### PR DESCRIPTION
This pull request includes changes to handle search type more gracefully and improve the handling of search parameters in the `main.go` file. The most important changes include modifying the `GetSearchType` function to return an empty string by default and updating the `Search` function to conditionally include the search type parameter only when it is not empty.

Changes to search type handling:

* [`internal/utils/search_type.go`](diffhunk://#diff-921da3fac53fc36e10b1702b268416a1f104cbdbcca86546def360b59d0a5837L20-R20): Modified the `GetSearchType` function to return an empty string instead of `SearchTypeVideoId` by default.

Improvements to search parameters handling:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L17-R20): Updated the `Search` function to conditionally include the `sp` parameter in the search query only if the search type is not empty.